### PR TITLE
Changed how suffix and prefix reads to match output from cutadapt

### DIFF
--- a/pipelines/fq2sortedbam/config
+++ b/pipelines/fq2sortedbam/config
@@ -1,18 +1,14 @@
-INPUT_DIR=/cold_storage/omics/genomes-indexes-reads/human/reads/broad/10k_PBMC_Multiome_nextgem_Chromium_Controller_fastqs/10k_PBMC_Multiome_nextgem_Chromium_Controller_atac/
-OUTPUT_DIR=/data/nfs_home/mvasimud/myworkspace/openomics/aws_all/output/
-export LD_PRELOAD=<absolute_path>/Open-Omics-Acceleration-Framework/pipelines/deepvariant-based-germline-variant-calling-fq2vcf/libmimalloc.so.2.0:$LD_PRELOAD
-REF=GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz
-
 ## Inputs for multifq bwa-mem2
 ## multiome-practice-may15_arcgtf_0.R1.trimmed_adapters.fastq.gz
 PREFIX="multiome-practice-may15_arcgtf"    ## prefix for R1 and R3 as input to bwamem2 in multifq
 SUFFIX="trimmed_adapters.fastq.gz"    ## suffix for R1 and R3 as input to bwamem2 in multifq
-
-## followin are inputs to fqprocess
-R1="10k_PBMC_Multiome_nextgem_Chromium_Controller_atac_S1_L001_R1_001.fastq.gz 10k_PBMC_Multiome_nextgem_Chromium_Controller_atac_S1_L002_R1_001.fastq.gz"
-R2="10k_PBMC_Multiome_nextgem_Chromium_Controller_atac_S1_L001_R2_001.fastq.gz 10k_PBMC_Multiome_nextgem_Chromium_Controller_atac_S1_L002_R2_001.fastq.gz"
-R3="10k_PBMC_Multiome_nextgem_Chromium_Controller_atac_S1_L001_R3_001.fastq.gz 10k_PBMC_Multiome_nextgem_Chromium_Controller_atac_S1_L002_R3_001.fastq.gz"
+INPUT_DIR=/home/awdeh/input_data
+OUTPUT_DIR=/home/awdeh/input_data/output
+R1="multiome-practice-may15_arcgtf_0.R1.trimmed_adapters.fastq.gz"
+R3="multiome-practice-may15_arcgtf_0.R3.trimmed_adapters.fastq.gz"
+R2=""
 I1=""
+REF=genome_referenceODrWMu/genome.fa
 
 # default values
 ISTART="False"   ## flag for bwa-mem2 index creation False/True

--- a/pipelines/fq2sortedbam/config
+++ b/pipelines/fq2sortedbam/config
@@ -9,6 +9,8 @@ R3="multiome-practice-may15_arcgtf_0.R3.trimmed_adapters.fastq.gz"
 R2=""
 I1=""
 REF=genome_referenceODrWMu/genome.fa
+## used + instead of - to avoid confusion in python parsing in dist_bwa
+PARAMS='+R "@RG\tID:RG1\tSM:RGSN1" +C' 
 
 # default values
 ISTART="False"   ## flag for bwa-mem2 index creation False/True
@@ -19,4 +21,3 @@ BAM_SIZE="5"   # in GB by default
 SAMPLE_ID=""
 OUTPUT_FORMAT="FASTQ"
 OUTFILE="broadfinal"    ##name of the output bam file
-PARAMS=""     ## bwa-mem2 paramas barring -t <threads> option

--- a/pipelines/fq2sortedbam/config
+++ b/pipelines/fq2sortedbam/config
@@ -4,8 +4,9 @@ export LD_PRELOAD=<absolute_path>/Open-Omics-Acceleration-Framework/pipelines/de
 REF=GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz
 
 ## Inputs for multifq bwa-mem2
-R1PREFIX="fastq_R1"    ## prefix for R1 as input to bwamem2 in multifq
-R3PREFIX="fastq_R3"    ## prefix for R1 as input to bwamem2 in multifq
+## multiome-practice-may15_arcgtf_0.R1.trimmed_adapters.fastq.gz
+PREFIX="multiome-practice-may15_arcgtf"    ## prefix for R1 and R3 as input to bwamem2 in multifq
+SUFFIX="trimmed_adapters.fastq.gz"    ## suffix for R1 and R3 as input to bwamem2 in multifq
 
 ## followin are inputs to fqprocess
 R1="10k_PBMC_Multiome_nextgem_Chromium_Controller_atac_S1_L001_R1_001.fastq.gz 10k_PBMC_Multiome_nextgem_Chromium_Controller_atac_S1_L002_R1_001.fastq.gz"

--- a/pipelines/fq2sortedbam/dist_bwa.py
+++ b/pipelines/fq2sortedbam/dist_bwa.py
@@ -375,8 +375,10 @@ def main(argv):
     parser.add_argument('--read2',default="", nargs='+',help="name of r2 files (for fqprocess) seperated by spaces")
     parser.add_argument('--read3',default="", nargs='+',help="name of r3 files (for fqprocess) seperated by spaces")
     parser.add_argument('--readi1',default="", nargs='+',help="name of i1 files (for fqprocess) seperated by spaces")
-    parser.add_argument('--r1prefix',default="", help="processed R1 files for bwa-mem2")
-    parser.add_argument('--r3prefix',default="", help="processed R3 files for bwa-mem2")
+    
+    parser.add_argument('--prefix',default="", help="prefix for processed R1 and R3 files for bwa-mem2")
+    parser.add_argument('--suffix',default="", help="suffix for processed R1 and R3 files for bwa-mem2")
+   
     parser.add_argument('--whitelist',default="whitelist.txt",help="10x whitelist file")
     parser.add_argument('--read_structure',default="16C",help="read structure")
     parser.add_argument('--barcode_orientation',default="FIRST_BP_RC",help="barcode orientation")
@@ -435,8 +437,10 @@ def main(argv):
     sample_id=args['sample_id']
     if sample_id == "": sample_id = output
     output_format = args["output_format"]
-    r1prefix=args["r1prefix"]  ## for mutlifq2sortedbam mode reading 'fqprocess' processed fastq files
-    r3prefix=args["r3prefix"]
+    
+    prefix=args["prefix"]  ## prefix for mutlifq2sortedbam mode reading 'fqprocess' processed fastq files
+    suffix=args["suffix"]  ## suffix for mutlifq2sortedbam mode reading 'fqprocess' processed fastq files
+    
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
     nranks = comm.Get_size()
@@ -569,8 +573,9 @@ def main(argv):
             for r in range(nranks):
                 #fn1 = "fastq_R1_" + str(r) + ".fastq.gz"
                 #fn2 = "fastq_R3_" + str(r) + ".fastq.gz"
-                fn1 = os.path.join(folder, r1prefix + "_" + str(r) + ".fastq.gz")
-                fn2 = os.path.join(folder, r3prefix + "_" + str(r) + ".fastq.gz")
+                #multiome-practice-may15_arcgtf_0.R1.trimmed_adapters.fastq.gz
+                fn1 = os.path.join(folder, prefix + "_" + str(r) + ".R1." + suffix)
+                fn2 =  os.path.join(folder, prefix + "_" + str(r) + ".R3." + suffix)
 
                 if os.path.isfile(fn1) == False or os.path.isfile(fn2) == False:
                     print(f"Error: Number of files fastq files ({r}) < number of ranks ({nranks})")
@@ -582,8 +587,8 @@ def main(argv):
         comm.barrier()
         #fn1 = "fastq_R1_" + str(rank) + ".fastq.gz"
         #fn2 = "fastq_R3_" + str(rank) + ".fastq.gz"
-        fn1 = os.path.join(folder, r1prefix + "_" + str(rank) + ".fastq.gz")
-        fn2 = os.path.join(folder, r3prefix + "_" + str(rank) + ".fastq.gz")
+        fn1 = os.path.join(folder, prefix + "_" + str(rank) + ".R1." + suffix)
+        fn2 = os.path.join(folder, prefix + "_" + str(rank) + ".R3." + suffix)
 
         #fn1 = folder + "/fastq_R1_" + str(rank) + ".fastq.gz"
         #fn2 = folder + "/fastq_R3_" + str(rank) + ".fastq.gz"

--- a/pipelines/fq2sortedbam/dist_bwa.py
+++ b/pipelines/fq2sortedbam/dist_bwa.py
@@ -402,6 +402,7 @@ def main(argv):
     args = vars(parser.parse_args())
     ifile=args["index"]
     params=args["params"]
+    params=params.replace("+","-") 
     if args["preads"] != None:
         ## for flatmode and pragzip mode
         rfile1=args["preads"][0]

--- a/pipelines/fq2sortedbam/run_bwa.sh
+++ b/pipelines/fq2sortedbam/run_bwa.sh
@@ -99,17 +99,17 @@ echo "mode: "$mode
 
 ## parameters
 READ1=${R1[@]}
-READ2=${R2[@]}
+#READ2=${R2[@]}
 READ3=${R3[@]}
 READI1=${I1[@]}
 
 echo "reads:"
 echo "READ1 $READ1"
-echo "READ2 $READ2"
+#echo "READ2 $READ2"
 echo "READ3 $READ3"
 echo "READI1 $READI1"
-echo "R1PREFIX $R1PREFIX"
-echo "R3PREFIX $R3PREFIX"
+echo "PREFIX $PREFIX"
+echo "SUFFIX $SUFFIX"
 
 whitelist=""
 read_structure=""
@@ -152,7 +152,7 @@ echo Starting run with $N ranks, $CPUS threads,$THREADS threads, $PPN ppn.
 # Todo : Make index creation parameterized.
 
 exec=dist_bwa.py
-mpiexec -bootstrap ssh -bind-to $BINDING -map-by $BINDING --hostfile hostfile -n $N -ppn $PPN python -u $exec --input $INDIR --output  $OUTDIR $TEMPDIR $REFDIR --index $REF --read1 $READ1 --read2 $READ2 --read3 $READ3 --cpus $CPUS --threads $THREADS --keep_unmapped ${whitelist} ${read_structure} ${barcode_orientation} ${bam_size} ${params} ${outfile} ${istart} ${sample_id} ${output_format} --r1prefix $R1PREFIX --r3prefix $R3PREFIX --mode $mode   2>&1 | tee ${OUTDIR}log.txt
+mpiexec -bootstrap ssh -bind-to $BINDING -map-by $BINDING --hostfile hostfile -n $N -ppn $PPN python -u $exec --input $INDIR --output  $OUTDIR $TEMPDIR $REFDIR --index $REF --read1 $READ1 --read3 $READ3 --cpus $CPUS --threads $THREADS --keep_unmapped ${whitelist} ${read_structure} ${barcode_orientation} ${bam_size} ${params} ${outfile} ${istart} ${sample_id} ${output_format} --prefix $PREFIX --suffix $SUFFIX --mode $mode   2>&1 | tee ${OUTDIR}log.txt
 
 
 


### PR DESCRIPTION
File format: `multiome-practice-may15_arcgtf_0.R1.trimmed_adapters.fastq.gz`

Added to `config`:
SUFFIX="multiome-practice-may15_arcgtf"
PREFIX="trimmed_adapters.fastq.gz"

Added to `dist_bwa.py`:
`fn1 = os.path.join(folder, prefix + "_" + str(rank) + ".R1." + suffix)`
`fn2 = os.path.join(folder, prefix + "_" + str(rank) + ".R3." + suffix)`


