### PR TITLE
Added error messages to script for bwa-mem2

### DIFF
--- a/pipelines/fq2sortedbam/run_bwa.sh
+++ b/pipelines/fq2sortedbam/run_bwa.sh
@@ -152,6 +152,18 @@ echo Starting run with $N ranks, $CPUS threads,$THREADS threads, $PPN ppn.
 # -in -sindex are required only once for indexing.
 # Todo : Make index creation parameterized.
 
+# Check if number of ranks equals number of splits
+if [ "$N" != ${#R1} ]; then
+    echo "Error: Number of ranks does not equal number of splits. Program failed."
+    exit 1
+fi
+
+# Check if number of R1 and R3 fastq files is equal
+if [ ${#R1} != ${#R3} ]; then
+    echo "Error: Number of R1 fastq files doesnt equal number of R3 files. Program failed."
+    exit 1
+fi
+
 exec=dist_bwa.py
 mpiexec -bootstrap ssh -bind-to $BINDING -map-by $BINDING --hostfile hostfile -n $N -ppn $PPN python -u $exec --input $INDIR --output  $OUTDIR $TEMPDIR $REFDIR --index $REF --read1 $READ1 --read3 $READ3 --cpus $CPUS --threads $THREADS --keep_unmapped ${whitelist} ${read_structure} ${barcode_orientation} ${bam_size} ${outfile} ${istart} ${sample_id} ${output_format} --prefix $PREFIX --suffix $SUFFIX --params "${PARAMS}" --mode $mode   2>&1 | tee ${OUTDIR}log.txt
 

--- a/pipelines/fq2sortedbam/run_bwa.sh
+++ b/pipelines/fq2sortedbam/run_bwa.sh
@@ -154,19 +154,21 @@ echo Starting run with $N ranks, $CPUS threads,$THREADS threads, $PPN ppn.
 
 # Check if number of ranks equals number of splits
 echo $R1; 
-echo $R2; 
 echo $R3; 
-echo ${#R1};
-echo ${#R2};
-echo ${#R3};
 
-if [ "$N" != ${#R1} ]; then
+R1_LEN=`echo $R1 | tr ' ' '\n' | wc -l`
+R3_LEN=`echo $R3 | tr ' ' '\n' | wc -l`
+
+echo $R1_LEN;
+echo $R3_LEN;
+
+if [ "$N" != "$R1_LEN" ]; then
     echo "Error: Number of ranks does not equal number of splits. Program failed."
     exit 1
 fi
 
 # Check if number of R1 and R3 fastq files is equal
-if [ ${#R1} != ${#R3} ]; then
+if [ "$R1_LEN" != "$R3_LEN" ]; then
     echo "Error: Number of R1 fastq files doesnt equal number of R3 files. Program failed."
     exit 1
 fi

--- a/pipelines/fq2sortedbam/run_bwa.sh
+++ b/pipelines/fq2sortedbam/run_bwa.sh
@@ -159,11 +159,8 @@ echo $R3;
 R1_LEN=`echo $R1 | tr ' ' '\n' | wc -l`
 R3_LEN=`echo $R3 | tr ' ' '\n' | wc -l`
 
-echo $R1_LEN;
-echo $R3_LEN;
-
 if [ "$N" != "$R1_LEN" ]; then
-    echo "Error: Number of ranks does not equal number of splits. Program failed."
+    echo "Error: Number of ranks ("$N") does not equal number of splits ("$R1_LEN"). Program failed."
     exit 1
 fi
 

--- a/pipelines/fq2sortedbam/run_bwa.sh
+++ b/pipelines/fq2sortedbam/run_bwa.sh
@@ -153,6 +153,13 @@ echo Starting run with $N ranks, $CPUS threads,$THREADS threads, $PPN ppn.
 # Todo : Make index creation parameterized.
 
 # Check if number of ranks equals number of splits
+echo $R1; 
+echo $R2; 
+echo $R3; 
+echo ${#R1};
+echo ${#R2};
+echo ${#R3};
+
 if [ "$N" != ${#R1} ]; then
     echo "Error: Number of ranks does not equal number of splits. Program failed."
     exit 1


### PR DESCRIPTION
These error messages check that the number of ranks equals number of splits, and the number R1 fastq files equals the number of R3 fastq files. 